### PR TITLE
Source order - Put scripts at bottom of page

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,61 +22,6 @@ limitations under the License.
     <title>CSS FilterLab</title>
     <link rel="stylesheet" href="style/css/app.css">
     <link rel="stylesheet" href="lib/third_party/CodeMirror/lib/codemirror.css">
-
-    <script src="lib/third_party/jquery/jquery-1.8.0.min.js"></script>
-    <script src="lib/third_party/jquery/jquery-ui-1.8.23.custom.min.js"></script>
-    <script src="lib/third_party/CodeMirror/lib/codemirror.js"></script>
-    <script src="lib/third_party/CodeMirror/mode/clike/clike.js"></script>
-
-    <script src="configs.js"></script>
-    <script src="lib/utils/utils.js"></script>
-    <script src="lib/utils/event_dispatcher.js"></script>
-    <script src="lib/application.js"></script>
-    <script src="lib/controls/base_control.js"></script>
-    <script src="lib/controls/code_editor.js"></script>
-    <script src="lib/controls/multi_control.js"></script>
-    <script src="lib/controls/color_control.js"></script>
-    <script src="lib/controls/checkbox_control.js"></script>
-    <script src="lib/controls/vector_control.js"></script>
-    <script src="lib/controls/editable_label.js"></script>
-    <script src="lib/controls/range_control.js"></script>
-    <script src="lib/controls/transform_control.js"></script>
-    <script src="lib/controls/text_control.js"></script>
-    <script src="lib/controls/warp_control.js"></script>
-    <script src="lib/models/active_object.js"></script>
-    <script src="lib/models/animation.js"></script>
-    <script src="lib/models/preset_store.js"></script>
-    <script src="lib/models/filter_config.js"></script>
-    <script src="lib/models/filter.js"></script>
-    <script src="lib/models/filter_store.js"></script>
-    <script src="lib/models/filter_list.js"></script>
-    <script src="lib/models/github.js"></script>
-    <script src="lib/models/keyframe.js"></script>
-    <script src="lib/utils/angle_lib.js"></script>
-    <script src="lib/utils/color_scheme.js"></script>
-    <script src="lib/utils/config.js"></script>
-    <script src="lib/utils/css_generators.js"></script>
-    <script src="lib/utils/local_storage.js"></script>
-    <script src="lib/utils/mixers.js"></script>
-    <script src="lib/utils/timer.js"></script>
-    <script src="lib/utils/warp_helpers.js"></script>
-    <script src="lib/views/filter_store_view.js"></script>
-    <script src="lib/views/active_filter_list_view.js"></script>
-    <script src="lib/views/css_code_view.js"></script>
-    <script src="lib/views/filter_item_view.js"></script>
-    <script src="lib/views/preset_store_view.js"></script>
-    <script src="lib/views/loading_progress_view.js"></script>
-    <script src="lib/views/logo_view.js"></script>
-    <script src="lib/views/help_view.js"></script>
-    <script src="lib/views/import_filter_view.js"></script>
-    <script src="lib/views/shader_editor_view.js"></script>
-    <script src="lib/views/shader_code_editor_view.js"></script>
-    <script src="lib/views/timeline_view.js"></script>
-
-    <script src="lib/views/dock_column.js"></script>
-    <script src="lib/views/dock_view.js"></script>
-    <script src="lib/views/dock_container.js"></script>
-    <script src="lib/views/dock_panel.js"></script>
 </head>
 
 <body>
@@ -461,5 +406,60 @@ limitations under the License.
 
         </section>
     </div>
+
+    <script src="lib/third_party/jquery/jquery-1.8.0.min.js"></script>
+    <script src="lib/third_party/jquery/jquery-ui-1.8.23.custom.min.js"></script>
+    <script src="lib/third_party/CodeMirror/lib/codemirror.js"></script>
+    <script src="lib/third_party/CodeMirror/mode/clike/clike.js"></script>
+
+    <script src="configs.js"></script>
+    <script src="lib/utils/utils.js"></script>
+    <script src="lib/utils/event_dispatcher.js"></script>
+    <script src="lib/application.js"></script>
+    <script src="lib/controls/base_control.js"></script>
+    <script src="lib/controls/code_editor.js"></script>
+    <script src="lib/controls/multi_control.js"></script>
+    <script src="lib/controls/color_control.js"></script>
+    <script src="lib/controls/checkbox_control.js"></script>
+    <script src="lib/controls/vector_control.js"></script>
+    <script src="lib/controls/editable_label.js"></script>
+    <script src="lib/controls/range_control.js"></script>
+    <script src="lib/controls/transform_control.js"></script>
+    <script src="lib/controls/text_control.js"></script>
+    <script src="lib/controls/warp_control.js"></script>
+    <script src="lib/models/active_object.js"></script>
+    <script src="lib/models/animation.js"></script>
+    <script src="lib/models/preset_store.js"></script>
+    <script src="lib/models/filter_config.js"></script>
+    <script src="lib/models/filter.js"></script>
+    <script src="lib/models/filter_store.js"></script>
+    <script src="lib/models/filter_list.js"></script>
+    <script src="lib/models/github.js"></script>
+    <script src="lib/models/keyframe.js"></script>
+    <script src="lib/utils/angle_lib.js"></script>
+    <script src="lib/utils/color_scheme.js"></script>
+    <script src="lib/utils/config.js"></script>
+    <script src="lib/utils/css_generators.js"></script>
+    <script src="lib/utils/local_storage.js"></script>
+    <script src="lib/utils/mixers.js"></script>
+    <script src="lib/utils/timer.js"></script>
+    <script src="lib/utils/warp_helpers.js"></script>
+    <script src="lib/views/filter_store_view.js"></script>
+    <script src="lib/views/active_filter_list_view.js"></script>
+    <script src="lib/views/css_code_view.js"></script>
+    <script src="lib/views/filter_item_view.js"></script>
+    <script src="lib/views/preset_store_view.js"></script>
+    <script src="lib/views/loading_progress_view.js"></script>
+    <script src="lib/views/logo_view.js"></script>
+    <script src="lib/views/help_view.js"></script>
+    <script src="lib/views/import_filter_view.js"></script>
+    <script src="lib/views/shader_editor_view.js"></script>
+    <script src="lib/views/shader_code_editor_view.js"></script>
+    <script src="lib/views/timeline_view.js"></script>
+
+    <script src="lib/views/dock_column.js"></script>
+    <script src="lib/views/dock_view.js"></script>
+    <script src="lib/views/dock_container.js"></script>
+    <script src="lib/views/dock_panel.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This has three changes:
- Removing white-space from index.html at the end of line
- `type`-attributes are not needed in HTML5, thus I removed them
- And the main thing: moving scripts to the bottom of the page. Please refer to http://developer.yahoo.com/performance/rules.html#js_bottom for further explanation.

Performance-wise this is a best-practice and I think people should see best practices when looking at the source code of this project.

I haven't found any bugs when working with the app and these commits.
Also I did not found tests to check if my observations are right.
