### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
EditorConfig helps to provide consistent coding style between different editors.

This commit includes an .editorconfig file with some defaults:
- default file-charset UTF-8
- whitespace at the end of a line is trimmed
- each file has at least one line at the end of the document that is empty
- line-endings are `lf` which is a good unix-default and works cross OS
- White-space is normally treated as spaces and one tab is 4 spaces.

EditorConfig [is supported](http://editorconfig.org/#download) in some IDEs.
